### PR TITLE
REQ-06: Migrated views from deprecated Kotlin Synthetic properties to view binding.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
 

--- a/app/src/main/java/com/egarcia/assignment/rentals/view/adapter/RentalAdapter.kt
+++ b/app/src/main/java/com/egarcia/assignment/rentals/view/adapter/RentalAdapter.kt
@@ -1,37 +1,37 @@
 package com.egarcia.assignment.rentals.view.adapter
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.egarcia.assignment.R
+import com.egarcia.assignment.databinding.ListingListItemBinding
 import com.egarcia.assignment.rentals.service.model.NetworkRental
 import com.egarcia.assignment.rentals.view.callback.RentalDiffCallback
 import com.squareup.picasso.Picasso
-import kotlinx.android.synthetic.main.listing_list_item.view.*
 
 /**
  * Used to display Listing objects
  */
-class RentalAdapter : PagedListAdapter<NetworkRental, RentalAdapter.ViewHolder>(RentalDiffCallback()) {
+class RentalAdapter :
+    PagedListAdapter<NetworkRental, RentalAdapter.ViewHolder>(RentalDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.listing_list_item, parent, false)
-        return ViewHolder(view)
+        val binding =
+            ListingListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         getItem(position)?.let { item -> holder.bind(item) }
     }
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class ViewHolder(private val binding: ListingListItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(networkRental: NetworkRental) {
-            itemView.name.text = networkRental.attributes.name
+            binding.name.text = networkRental.attributes.name
             networkRental.attributes.primaryImageUrl?.let {
                 Picasso.with(itemView.context).load(it)
-                        .fit().centerCrop().into(itemView.primary_image)
+                    .fit().centerCrop().into(binding.primaryImage)
             }
         }
     }

--- a/app/src/main/java/com/egarcia/assignment/rentals/view/ui/RentalListActivity.kt
+++ b/app/src/main/java/com/egarcia/assignment/rentals/view/ui/RentalListActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.View
+import android.widget.ProgressBar
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -17,7 +18,6 @@ import com.egarcia.assignment.utils.ProgressStatus
 import com.egarcia.assignment.view.BaseActivity
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.rental_list.*
 
 /**
  * Displays a list of Listings
@@ -30,6 +30,7 @@ class RentalListActivity : BaseActivity(), androidx.appcompat.widget.SearchView.
     private lateinit var adapter: RentalAdapter
     private lateinit var binding: ActivityRentalListBinding
     private lateinit var snackbar: Snackbar
+    private lateinit var progressBar: ProgressBar
     //endregion
 
     //region Lifecycle
@@ -42,6 +43,7 @@ class RentalListActivity : BaseActivity(), androidx.appcompat.widget.SearchView.
         binding.toolbar.title = title
 
         setupRecyclerView(binding.listLayout.rentalList)
+        progressBar = binding.listLayout.progressBar
         snackbar = Snackbar.make(binding.coordinator,
                 R.string.error_message_generic, Snackbar.LENGTH_INDEFINITE)
         snackbar.setAction(R.string.retry) { viewModel.refresh() }


### PR DESCRIPTION
The Kotlin Android Extensions plugin along with the Kotlin Synthetic properties were deprecated since they tend to pollute the global namespace, don't expose nullability information, among other disadvantages. 

The current recommendation from the Google team is to use either View Binding or Data Binding. At the moment, View Binding has been chosen for its faster compilation time since this project doesn't currently need 2 way binding capabilities.